### PR TITLE
Add index page for simple site

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ account with username `admin` and password `admin`.
 
 ## Running
 
-Execute the script with Python 3:
+Open `index.html` in a browser for a simple landing page or execute the script with Python 3:
 
 ```bash
 python3 main.py

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mohamed Inc User Manager</title>
+</head>
+<body>
+    <h1>Welcome to Mohamed Inc User Manager</h1>
+    <p>Run the Python script on the server to manage accounts.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- provide a minimal HTML `index.html` so the server shows a landing page instead of the README
- mention the page in the README

## Testing
- `python3 -m py_compile main.py`
- `python3 main.py <<'EOF'
3
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68561e634f6483298b0bf742c69918bf