### PR TITLE
Add web login interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,17 @@ account with username `admin` and password `admin`.
 
 ## Running
 
-Open `index.html` in a browser for a simple landing page or execute the script with Python 3:
+You can either use the command line tool or the lightweight web interface.
+
+To start the web interface run:
+
+```bash
+python3 server.py
+```
+
+Then open `http://localhost:8000` in your browser. Admin users can create or delete accounts from the admin panel.
+
+Alternatively execute the script with Python 3:
 
 ```bash
 python3 main.py

--- a/index.html
+++ b/index.html
@@ -7,6 +7,74 @@
 </head>
 <body>
     <h1>Welcome to Mohamed Inc User Manager</h1>
-    <p>Run the Python script on the server to manage accounts.</p>
+    <form id="login-form">
+        <input type="text" id="username" placeholder="Username" required>
+        <input type="password" id="password" placeholder="Password" required>
+        <button type="submit">Login</button>
+    </form>
+    <div id="message"></div>
+    <div id="admin-panel" style="display:none;">
+        <h2>Admin panel</h2>
+        <form id="create-form">
+            <input type="text" id="new-user" placeholder="Username" required>
+            <input type="password" id="new-pass" placeholder="Password" required>
+            <button type="submit">Create account</button>
+        </form>
+        <form id="delete-form">
+            <input type="text" id="del-user" placeholder="User to delete" required>
+            <button type="submit">Delete account</button>
+        </form>
+        <pre id="user-list"></pre>
+    </div>
+<script>
+document.getElementById('login-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const res = await fetch('/login', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+            username: document.getElementById('username').value,
+            password: document.getElementById('password').value
+        })
+    });
+    const data = await res.json();
+    document.getElementById('message').innerText = data.message;
+    if (data.admin) {
+        document.getElementById('admin-panel').style.display = 'block';
+        loadUsers();
+    }
+});
+
+async function loadUsers() {
+    const res = await fetch('/users');
+    if (res.ok) {
+        const users = await res.json();
+        document.getElementById('user-list').innerText = JSON.stringify(users, null, 2);
+    }
+}
+
+document.getElementById('create-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    await fetch('/create', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+            username: document.getElementById('new-user').value,
+            password: document.getElementById('new-pass').value
+        })
+    });
+    loadUsers();
+});
+
+document.getElementById('delete-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    await fetch('/delete', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({username: document.getElementById('del-user').value})
+    });
+    loadUsers();
+});
+</script>
 </body>
 </html>

--- a/server.py
+++ b/server.py
@@ -1,0 +1,81 @@
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import json
+from main import load_users, save_users, hash_password, create_account, ensure_admin
+
+current_user = None
+
+class Handler(BaseHTTPRequestHandler):
+    def _send_json(self, data, status=200):
+        self.send_response(status)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(json.dumps(data).encode())
+
+    def do_GET(self):
+        if self.path in ('/', '/index.html'):
+            with open('index.html', 'rb') as f:
+                self.send_response(200)
+                self.send_header('Content-Type', 'text/html')
+                self.end_headers()
+                self.wfile.write(f.read())
+        elif self.path == '/users':
+            if current_user != 'admin':
+                self.send_response(403)
+                self.end_headers()
+                return
+            users = load_users()
+            self._send_json(users)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_POST(self):
+        global current_user
+        length = int(self.headers.get('Content-Length', 0))
+        body = self.rfile.read(length).decode()
+        data = json.loads(body or '{}')
+
+        if self.path == '/login':
+            username = data.get('username')
+            password = data.get('password')
+            users = load_users()
+            user = users.get(username)
+            if user and user['password'] == hash_password(password):
+                current_user = username
+                self._send_json({'message': 'Login successful.', 'admin': user.get('is_admin', False)})
+            else:
+                self._send_json({'message': 'Invalid credentials.', 'admin': False}, status=401)
+        elif self.path == '/create':
+            if current_user != 'admin':
+                self.send_response(403)
+                self.end_headers()
+                return
+            username = data.get('username')
+            password = data.get('password')
+            create_account(username, password)
+            self._send_json({'status': 'ok'})
+        elif self.path == '/delete':
+            if current_user != 'admin':
+                self.send_response(403)
+                self.end_headers()
+                return
+            username = data.get('username')
+            users = load_users()
+            if username in users and username != 'admin':
+                del users[username]
+                save_users(users)
+            self._send_json({'status': 'ok'})
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+def run(server_class=HTTPServer, handler_class=Handler):
+    ensure_admin()
+    server_address = ('', 8000)
+    httpd = server_class(server_address, handler_class)
+    print('Server running at http://localhost:8000')
+    httpd.serve_forever()
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
## Summary
- add a simple HTTP server with login and admin endpoints
- expand the HTML page with login form and admin panel
- document how to run the web interface in README

## Testing
- `python3 -m py_compile main.py server.py`
- `python3 server.py` *(started and terminated to verify launch)*

------
https://chatgpt.com/codex/tasks/task_e_68561fd10ca083298a6e9711ad1e2f5c