### PR TITLE
Add user registration via web

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ python3 server.py
 ```
 
 Then open `http://localhost:8000` in your browser. Admin users can create or delete accounts from the admin panel.
+Regular users can sign up using the registration form on the front page.
 
 Alternatively execute the script with Python 3:
 

--- a/index.html
+++ b/index.html
@@ -12,6 +12,12 @@
         <input type="password" id="password" placeholder="Password" required>
         <button type="submit">Login</button>
     </form>
+    <h2>Register</h2>
+    <form id="register-form">
+        <input type="text" id="reg-user" placeholder="Username" required>
+        <input type="password" id="reg-pass" placeholder="Password" required>
+        <button type="submit">Sign up</button>
+    </form>
     <div id="message"></div>
     <div id="admin-panel" style="display:none;">
         <h2>Admin panel</h2>
@@ -43,6 +49,20 @@ document.getElementById('login-form').addEventListener('submit', async (e) => {
         document.getElementById('admin-panel').style.display = 'block';
         loadUsers();
     }
+});
+
+document.getElementById('register-form').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const res = await fetch('/register', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({
+            username: document.getElementById('reg-user').value,
+            password: document.getElementById('reg-pass').value
+        })
+    });
+    const data = await res.json();
+    document.getElementById('message').innerText = data.message;
 });
 
 async function loadUsers() {

--- a/server.py
+++ b/server.py
@@ -45,6 +45,15 @@ class Handler(BaseHTTPRequestHandler):
                 self._send_json({'message': 'Login successful.', 'admin': user.get('is_admin', False)})
             else:
                 self._send_json({'message': 'Invalid credentials.', 'admin': False}, status=401)
+        elif self.path == '/register':
+            username = data.get('username')
+            password = data.get('password')
+            users = load_users()
+            if username in users:
+                self._send_json({'message': 'User already exists.'}, status=400)
+            else:
+                create_account(username, password)
+                self._send_json({'message': 'Account created.'})
         elif self.path == '/create':
             if current_user != 'admin':
                 self.send_response(403)


### PR DESCRIPTION
## Summary
- add a registration form to the web UI
- support `/register` endpoint in the HTTP server
- document signup feature in the README

## Testing
- `python3 -m py_compile main.py server.py`
- Manual curl tests of `/register` and `/login`

------
https://chatgpt.com/codex/tasks/task_e_6857802528588329ac4bd93abaa8dc9f