### PR TITLE
Implement basic dashboard layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,19 @@
         </form>
         <pre id="user-list"></pre>
     </div>
+
+    <div id="dashboard" style="display:none;">
+        <h2>Dashboard</h2>
+        <nav>
+            <ul>
+                <li><a href="#stocks">Stocks</a></li>
+                <li><a href="#crypto">Crypto</a></li>
+                <li><a href="#assets">Assets</a></li>
+                <li><a href="#reserves">Reserves</a></li>
+                <li><a href="#cash">Cash</a></li>
+            </ul>
+        </nav>
+    </div>
 <script>
 document.getElementById('login-form').addEventListener('submit', async (e) => {
     e.preventDefault();
@@ -45,9 +58,14 @@ document.getElementById('login-form').addEventListener('submit', async (e) => {
     });
     const data = await res.json();
     document.getElementById('message').innerText = data.message;
-    if (data.admin) {
-        document.getElementById('admin-panel').style.display = 'block';
-        loadUsers();
+    if (res.ok) {
+        document.getElementById('login-form').style.display = 'none';
+        document.getElementById('register-form').style.display = 'none';
+        document.getElementById('dashboard').style.display = 'block';
+        if (data.admin) {
+            document.getElementById('admin-panel').style.display = 'block';
+            loadUsers();
+        }
     }
 });
 


### PR DESCRIPTION
## Summary
- add a hidden Dashboard section with a simple menu for **Stocks**, **Crypto**, **Assets**, **Reserves**, and **Cash**
- reveal the dashboard and hide login/registration forms after successful login

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_685785cc449483299216476029b68f4c