### PR TITLE
Implement cookie-based sessions

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,17 +1,41 @@
 from http.server import HTTPServer, BaseHTTPRequestHandler
 import json
+import uuid
+from http.cookies import SimpleCookie
 from main import load_users, save_users, hash_password, create_account, ensure_admin
 
 ADMIN_PASSWORD = "258963"
 
-current_user = None
+sessions = {}
 
 class Handler(BaseHTTPRequestHandler):
-    def _send_json(self, data, status=200):
+    def _send_json(self, data, status=200, headers=None):
         self.send_response(status)
         self.send_header('Content-Type', 'application/json')
+        if headers:
+            for key, value in headers.items():
+                self.send_header(key, value)
         self.end_headers()
         self.wfile.write(json.dumps(data).encode())
+
+    def _get_session_user(self):
+        cookie_header = self.headers.get('Cookie')
+        if not cookie_header:
+            return None
+        cookie = SimpleCookie()
+        cookie.load(cookie_header)
+        token = cookie.get('session')
+        if not token:
+            return None
+        return sessions.get(token.value)
+
+    def _require_admin(self):
+        user = self._get_session_user()
+        if user != 'admin':
+            self.send_response(403)
+            self.end_headers()
+            return False
+        return True
 
     def do_GET(self):
         if self.path in ('/', '/index.html'):
@@ -21,9 +45,7 @@ class Handler(BaseHTTPRequestHandler):
                 self.end_headers()
                 self.wfile.write(f.read())
         elif self.path == '/users':
-            if current_user != 'admin':
-                self.send_response(403)
-                self.end_headers()
+            if not self._require_admin():
                 return
             users = load_users()
             self._send_json(users)
@@ -32,7 +54,6 @@ class Handler(BaseHTTPRequestHandler):
             self.end_headers()
 
     def do_POST(self):
-        global current_user
         length = int(self.headers.get('Content-Length', 0))
         body = self.rfile.read(length).decode()
         data = json.loads(body or '{}')
@@ -40,23 +61,21 @@ class Handler(BaseHTTPRequestHandler):
         if self.path == '/auth':
             password = data.get('password')
             if password == ADMIN_PASSWORD:
-                current_user = 'admin'
-                self._send_json({'message': 'Access granted.'})
+                token = uuid.uuid4().hex
+                sessions[token] = 'admin'
+                headers = {'Set-Cookie': f'session={token}; HttpOnly; Path=/'}
+                self._send_json({'message': 'Access granted.'}, headers=headers)
             else:
                 self._send_json({'message': 'Invalid password.'}, status=401)
         elif self.path == '/create':
-            if current_user != 'admin':
-                self.send_response(403)
-                self.end_headers()
+            if not self._require_admin():
                 return
             username = data.get('username')
             password = data.get('password')
             create_account(username, password)
             self._send_json({'status': 'ok'})
         elif self.path == '/delete':
-            if current_user != 'admin':
-                self.send_response(403)
-                self.end_headers()
+            if not self._require_admin():
                 return
             username = data.get('username')
             users = load_users()
@@ -64,6 +83,19 @@ class Handler(BaseHTTPRequestHandler):
                 del users[username]
                 save_users(users)
             self._send_json({'status': 'ok'})
+        elif self.path == '/logout':
+            token = None
+            cookie_header = self.headers.get('Cookie')
+            if cookie_header:
+                cookie = SimpleCookie()
+                cookie.load(cookie_header)
+                token_cookie = cookie.get('session')
+                if token_cookie:
+                    token = token_cookie.value
+            if token:
+                sessions.pop(token, None)
+            headers = {'Set-Cookie': 'session=; Max-Age=0; Path=/; HttpOnly'}
+            self._send_json({'message': 'Logged out'}, headers=headers)
         else:
             self.send_response(404)
             self.end_headers()


### PR DESCRIPTION
## Summary
- add in-memory cookie sessions to track auth
- validate cookie for privileged routes and add logout

## Testing
- `python3 -m py_compile server.py`
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6858ba92c9588329822b31aa48fd5b29